### PR TITLE
Add support for sequential calls with futures

### DIFF
--- a/base-utils/src/main/scala/uk/co/telegraph/utils/futures/SequentialFutures.scala
+++ b/base-utils/src/main/scala/uk/co/telegraph/utils/futures/SequentialFutures.scala
@@ -1,0 +1,24 @@
+package uk.co.telegraph.utils.futures
+
+import scala.collection.mutable
+import scala.concurrent.{ExecutionContext, Future}
+
+trait SequentialFutures {
+  implicit val executionContext: ExecutionContext
+
+  def sequentialFutures[A, B](items: Seq[A], limit: Int)(fn: Seq[A] => Future[B]): Future[List[B]] = {
+    val base = Future.successful(mutable.ListBuffer.empty[B])
+    items
+      .grouped(limit)
+      .foldLeft(base) {
+        (futureRes, group) =>
+          futureRes.flatMap {
+            res => {
+              fn(group).map(y => res += y)
+            }
+          }
+      }
+      .map(_.toList)
+  }
+
+}


### PR DESCRIPTION
The util trait prevents the usage of await for the scenario when futures need to be run sequentially.